### PR TITLE
fix: menu flicker when searching

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -544,7 +544,8 @@ const App = () => {
             flexDirection: 'column', 
             alignItems: 'center', 
             marginTop: '2rem',
-            width: '100%'
+            width: '100%',
+            height: '100%',
         }}>
             <div className="logo-container" onClick={() => {
                 setSearchTerm('');

--- a/src/index.css
+++ b/src/index.css
@@ -17,7 +17,7 @@ body {
     min-height: 100vh;
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     color: var(--text-primary);
     background-color: var(--background-color);
@@ -25,7 +25,9 @@ body {
 }
 
 #root {
+    box-sizing: border-box;
     max-width: 1200px;
+    height: 100vh;
     width: 100%;
     margin: 0 auto;
     padding: 2rem;
@@ -294,7 +296,7 @@ button:disabled {
     padding: 2rem 0;
     font-size: 0.95rem;
     font-style: italic;
-    margin-top: 2rem;
+    margin-top: auto;
     letter-spacing: 0.3px;
 }
 


### PR DESCRIPTION
Anchors the search menu to the top instead of centering it so when the search results appear the search menu doesn't flicker up and down. The layout otherwise looks identical though.

Also stickies the footer to the bottom so if there are only 1-2 results it doesn't crawl up the page under the pagination buttons

![image](https://github.com/user-attachments/assets/c5e0b648-4773-461c-a023-11d68ffbd951)
