### PR TITLE
feat: search result highlighting

### DIFF
--- a/models/postgres.js
+++ b/models/postgres.js
@@ -212,7 +212,7 @@ const quoteModel = {
     let query = `
       SELECT q.video_id, q.title, q.upload_date, q.channel_source,
              json_agg(json_build_object(
-               'text', q.text,
+               'text', ts_headline('simple', q.text, websearch_to_tsquery('simple', $1)),
                'line_number', q.line_number,
                'timestamp_start', q.timestamp_start,
                'title', q.title,          -- Keep for context within quote object

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.7.7",
         "cors": "^2.8.5",
         "date-fns": "^4.1.0",
+        "dompurify": "^3.2.4",
         "dotenv": "^16.4.5",
         "express": "^4.21.1",
         "express-rate-limit": "^7.1.5",
@@ -1461,6 +1462,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
@@ -2792,6 +2800,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dotenv": {

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "start": "node index.js"
   },
   "dependencies": {
+    "@vitejs/plugin-react": "^4.3.4",
     "axios": "^1.7.7",
     "cors": "^2.8.5",
     "date-fns": "^4.1.0",
+    "dompurify": "^3.2.4",
     "dotenv": "^16.4.5",
     "express": "^4.21.1",
     "express-rate-limit": "^7.1.5",
@@ -28,8 +30,7 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.27.0",
     "redis": "^4.7.0",
-    "vite": "^6.2.2",
-    "@vitejs/plugin-react": "^4.3.4"
+    "vite": "^6.2.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",

--- a/src/index.css
+++ b/src/index.css
@@ -47,6 +47,10 @@ body {
     filter: drop-shadow(0 0 2em #61dafbaa);
 }
 
+.quote-item b {
+  color: #9ecaff;
+}
+
 @keyframes logo-spin {
     from {
         transform: rotate(0deg);


### PR DESCRIPTION
A concern I've got right rn: is the query parameter passed to postgres always on index 1? As in is there anything wrong with this hardcoded expression? `ts_headline('simple', q.text, websearch_to_tsquery('simple', $1))` I'm like 80% sure it's always on index 1

Changes:
* Returning results wrapped in `<b>` tags to highlight them from search results
* Added [`dompurify`](https://github.com/cure53/DOMPurify) to make sure there's no XSS vulnerability with rendering `<b>` tags 4 years down the line when we forget it even exists
* Aligned the report flags to the right
* Refactored the timestamp creation logic
* Fixed the bug where quotes said at the 0th second of videos like `hello to all the gamers` links to -1:-1

<img width="1498" alt="image" src="https://github.com/user-attachments/assets/a30d6706-61c5-433f-bc5d-ba693ad94b56" />