### PR TITLE
Enhance NL logo click event and fix content overlap issue

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,7 +2,6 @@
 @media (max-width: 768px) {
   /* Mobile logo styles - significantly increased size */
   .logo-container {
-      position: sticky;
       top: 0;
       background-color: var(--bg-color);
       width: 100%;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -686,6 +686,15 @@ const App = () => {
         }
     };
 
+    const handleLogoClick = () => {
+        window.scrollTo(0, 0);
+        setSearchTerm("");
+        setQuotes([]);
+        setHasSearched(false);
+        setPage(1);
+        navigate("/");
+    };
+
     return (
         <div style={{
             display: 'flex',
@@ -695,13 +704,7 @@ const App = () => {
             width: '100%',
             height: '100%',
         }}>
-            <div className="logo-container" onClick={() => {
-                setSearchTerm('');
-                setQuotes([]);
-                setHasSearched(false);
-                setPage(1);
-                navigate('/');
-            }}>
+            <div className="logo-container" onClick={handleLogoClick}>
                 <img 
                     src="/NLogo.webp" 
                     alt="Northernlion Logo"


### PR DESCRIPTION
The NL logo was covering some of the elements in the `.input-container` div due to `position: sticky` on small devices. I removed the sticky positioning to address this bug.

I also enhanced the click event handler to scroll to the top of the page when it is clicked, to add a visual indicator that the search form and filters were reset.

## Preview

**Before**
![nl-2-before](https://github.com/user-attachments/assets/a146f827-59f3-4be0-92c1-54043affaa6b)

**After**
![nl-2-after](https://github.com/user-attachments/assets/ae64d359-6cec-4231-9928-b85af15f00b1)